### PR TITLE
Add support for commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,14 @@ opt-level = "s"
 lto = true
 
 [dependencies]
+async-trait = "0.1.51"
 console_error_panic_hook = { version = "0.1.5", optional = true }
 console_log = { version = "0.2", optional = true, features = ["color"] }
 js-sys = "0.3.51"
 lazy_static = "1.4.0"
 log = "0.4"
 wasm-bindgen = "0.2.63"
+wasm-bindgen-futures = "0.4.24"
 web-sys = { version = "0.3.51", features = ["console", "Document", "Element", "HtmlCollection", "HtmlElement", "HtmlInputElement", "InputEvent", "Node", "NodeList", "Text", "Window"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,31 @@ console_log = { version = "0.2", optional = true, features = ["color"] }
 js-sys = "0.3.51"
 lazy_static = "1.4.0"
 log = "0.4"
-wasm-bindgen = "0.2.63"
+serde = { version = "1.0.127", features = ["derive"] }
+serde_json = "1.0.66"
+wasm-bindgen = { version = "0.2.63", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.24"
-web-sys = { version = "0.3.51", features = ["console", "Document", "Element", "HtmlCollection", "HtmlElement", "HtmlInputElement", "InputEvent", "Node", "NodeList", "Text", "Window"] }
+
+[dependencies.web-sys]
+version = "0.3.51"
+features = [
+  "Document",
+  "Element",
+  "Headers",
+  "HtmlCollection",
+  "HtmlElement",
+  "HtmlInputElement",
+  "InputEvent",
+  "Node",
+  "NodeList",
+  "Request",
+  "RequestInit",
+  "RequestMode",
+  "Response",
+  "Text",
+  "Window",
+  "console"
+]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,10 +1,10 @@
-use crate::{renderer::Renderer, virtual_dom::Html};
+use crate::{command::Commands, renderer::Renderer, virtual_dom::Html};
 use std::{cell::Ref, cell::RefCell, fmt, rc::Rc};
 use wasm_bindgen::prelude::*;
 
 struct State<Model, Message> {
     model: Model,
-    html: Option<Html<Message>>,
+    html: Html<Message>,
 }
 
 impl<Model, Message> State<Model, Message>
@@ -12,14 +12,7 @@ where
     Model: Clone,
 {
     fn new(model: Model, html: Html<Message>) -> Self {
-        Self {
-            model,
-            html: Some(html),
-        }
-    }
-
-    fn initial(model: Model) -> Self {
-        Self { model, html: None }
+        Self { model, html }
     }
 }
 
@@ -28,59 +21,68 @@ pub struct App<Model, Message, Init, Update, View> {
     update: Rc<Update>,
     view: Rc<View>,
     root_id: String,
-    state: Rc<RefCell<State<Model, Message>>>,
+    state: Rc<RefCell<Option<State<Model, Message>>>>,
 }
 
 impl<Model, Message, Init, Update, View> App<Model, Message, Init, Update, View>
 where
     Model: 'static + Clone + fmt::Debug + Eq,
     Message: 'static + Clone + fmt::Debug,
-    Init: 'static + Fn() -> Model,
-    Update: 'static + Fn(&Message, &Model) -> Model,
+    Init: 'static + Fn() -> (Model, Commands<Message>),
+    Update: 'static + Fn(&Message, &Model) -> (Model, Commands<Message>),
     View: 'static + Fn(&Model) -> Html<Message>,
 {
     pub fn new(init: Init, update: Update, view: View, root_id: &str) -> Self {
-        let state = State::initial(init());
-
         Self {
             init: Rc::new(init),
             update: Rc::new(update),
             view: Rc::new(view),
             root_id: root_id.into(),
-            state: Rc::new(RefCell::new(state)),
+            state: Rc::new(RefCell::new(None)),
         }
     }
 
     pub fn start(&self) {
-        let model = self.state().model.clone();
-        let html = (self.view)(&model);
-        self.render_app(&html).unwrap();
-        self.set_state(State::new(model, html));
+        let (model, commands) = (self.init)();
+
+        self.update(model, commands);
     }
 
     pub fn handle_message(&self, message: &Message) {
-        let new_model = (self.update)(message, &self.state().model);
-        if new_model == self.state().model {
+        let (new_model, commands) = (self.update)(message, &self.state().as_ref().unwrap().model);
+
+        if new_model == self.state().as_ref().unwrap().model {
             return;
         }
 
-        let new_html = (self.view)(&new_model);
-        self.render_app(&new_html).unwrap();
-
-        self.set_state(State::new(new_model, new_html));
+        self.update(new_model, commands);
     }
 
-    fn state(&self) -> Ref<State<Model, Message>> {
-        (*self.state).borrow()
+    fn update(&self, model: Model, commands: Commands<Message>) {
+        let new_html = (self.view)(&model);
+        self.render_app(&new_html).unwrap();
+
+        self.handle_commands(commands);
+        self.set_state(State::new(model, new_html));
+    }
+
+    fn handle_commands(&self, commands: Commands<Message>) {}
+
+    fn state(&self) -> Ref<Option<State<Model, Message>>> {
+        (self.state).borrow()
     }
 
     fn set_state(&self, state: State<Model, Message>) {
-        self.state.replace(state);
+        self.state.replace(Some(state));
     }
 
     fn render_app(&self, html: &Html<Message>) -> Result<(), JsValue> {
         let renderer = Renderer::new(self);
-        renderer.render(&self.state().html, html, &self.root_id)
+        renderer.render(
+            self.state().as_ref().map(|state| &state.html),
+            html,
+            &self.root_id,
+        )
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,5 @@
 use crate::{command::Commands, renderer::Renderer, virtual_dom::Html};
+use log::info;
 use std::{cell::Ref, cell::RefCell, fmt, rc::Rc};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::spawn_local;
@@ -50,6 +51,8 @@ where
     }
 
     pub fn handle_message(&self, message: &Message) {
+        info!("message: {:#?}", message);
+
         let (new_model, commands) = (self.update)(message, &self.state().as_ref().unwrap().model);
 
         if new_model == self.state().as_ref().unwrap().model {
@@ -60,6 +63,8 @@ where
     }
 
     fn update(&self, model: Model, commands: Commands<Message>) {
+        info!("model: {:#?}", model);
+
         let new_html = (self.view)(&model);
         self.render_app(&new_html).unwrap();
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,5 +1,8 @@
+use async_trait::async_trait;
+
+#[async_trait]
 pub trait Command<Message> {
-    fn run(&self);
+    async fn run(&self) -> Message;
 
     fn boxed(self) -> Box<Self>
     where

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,0 +1,12 @@
+pub trait Command<Message> {
+    fn run(&self);
+
+    fn boxed(self) -> Box<Self>
+    where
+        Self: Sized,
+    {
+        Box::new(self)
+    }
+}
+
+pub type Commands<T> = Vec<Box<dyn Command<T>>>;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-#[async_trait]
+#[async_trait(?Send)]
 pub trait Command<Message> {
     async fn run(&self) -> Message;
 
@@ -12,4 +12,5 @@ pub trait Command<Message> {
     }
 }
 
-pub type Commands<T> = Vec<Box<dyn Command<T>>>;
+pub type Boxed<T> = Box<dyn Command<T>>;
+pub type Commands<T> = Vec<Boxed<T>>;

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,0 +1,54 @@
+use crate::command::Command;
+use async_trait::async_trait;
+use serde::de::DeserializeOwned;
+use wasm_bindgen::{prelude::*, JsCast};
+use wasm_bindgen_futures::JsFuture;
+use web_sys::{Request, RequestInit, RequestMode, Response};
+
+pub struct Fetch<Data, Message> {
+    url: String,
+    handler: Box<dyn Fn(Result<Data, JsValue>) -> Message>,
+}
+
+impl<Data, Message> Fetch<Data, Message>
+where
+    Data: DeserializeOwned,
+{
+    pub fn new<Handler>(url: &str, handler: Handler) -> Self
+    where
+        Handler: 'static + Fn(Result<Data, JsValue>) -> Message,
+    {
+        Self {
+            url: url.into(),
+            handler: Box::new(handler),
+        }
+    }
+
+    async fn perform(&self) -> Result<Data, JsValue> {
+        let mut opts = RequestInit::new();
+        opts.method("GET");
+        opts.mode(RequestMode::Cors);
+
+        let request = Request::new_with_str_and_init(&self.url, &opts).unwrap();
+
+        let window = web_sys::window().unwrap();
+
+        let response: Response = JsFuture::from(window.fetch_with_request(&request))
+            .await?
+            .dyn_into()?;
+        let json = JsFuture::from(response.json()?).await?;
+
+        json.into_serde().map_err(|e| e.to_string().into())
+    }
+}
+
+#[async_trait(?Send)]
+impl<Data, Message> Command<Message> for Fetch<Data, Message>
+where
+    Data: DeserializeOwned,
+{
+    async fn run(&self) -> Message {
+        let result = self.perform().await;
+        (self.handler)(result)
+    }
+}

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,0 +1,22 @@
+use crate::{
+    command::{self, Command},
+    fetch::Fetch,
+};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::JsValue;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct PullRequest {
+    pub number: u32,
+    pub state: String,
+    pub title: String,
+}
+
+pub fn get_pull_requests<Message, Handler>(repo: &str, handler: Handler) -> command::Boxed<Message>
+where
+    Message: 'static,
+    Handler: 'static + Fn(Result<Vec<PullRequest>, JsValue>) -> Message,
+{
+    let url = format!("https://api.github.com/repos/{}/pulls?state=all", repo);
+    Fetch::new(&url, move |result| handler(result)).boxed()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 mod app;
+mod command;
 mod renderer;
 mod virtual_dom;
 
 use app::App;
+use command::Commands;
 use virtual_dom::{Attribute, Html};
 use wasm_bindgen::prelude::*;
 
@@ -51,16 +53,18 @@ enum Message {
     ChangeText(String),
 }
 
-fn init() -> Model {
-    Model::default()
+fn init() -> (Model, Commands<Message>) {
+    (Model::default(), vec![])
 }
 
-fn update(message: &Message, model: &Model) -> Model {
-    match message {
+fn update(message: &Message, model: &Model) -> (Model, Commands<Message>) {
+    let model = match message {
         Message::Increment => model.increment(),
         Message::Decrement => model.decrement(),
         Message::ChangeText(text) => model.change_text(text),
-    }
+    };
+
+    (model, vec![])
 }
 
 fn view(model: &Model) -> Html<Message> {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -99,7 +99,7 @@ where
 
     fn replace_child(element: &Element, index: u32, new: &Node) -> Result<(), JsValue> {
         let old = Self::get_child(element, index)?;
-        element.replace_child(&old, new)?;
+        element.replace_child(new, &old)?;
 
         Ok(())
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,5 +1,6 @@
 use crate::{
     app::App,
+    command::Commands,
     virtual_dom::{self, Html},
 };
 use std::fmt;
@@ -15,8 +16,8 @@ impl<Model, Message, Init, Update, View> Renderer<Model, Message, Init, Update, 
 where
     Model: 'static + Clone + fmt::Debug + Eq,
     Message: 'static + Clone + fmt::Debug,
-    Init: 'static + Fn() -> Model,
-    Update: 'static + Fn(&Message, &Model) -> Model,
+    Init: 'static + Fn() -> (Model, Commands<Message>),
+    Update: 'static + Fn(&Message, &Model) -> (Model, Commands<Message>),
     View: 'static + Fn(&Model) -> Html<Message>,
 {
     pub fn new(app: &App<Model, Message, Init, Update, View>) -> Self {
@@ -28,7 +29,7 @@ where
 
     pub fn render(
         &self,
-        old: &Option<Html<Message>>,
+        old: Option<&Html<Message>>,
         new: &Html<Message>,
         root_id: &str,
     ) -> Result<(), JsValue>
@@ -36,7 +37,7 @@ where
         Message: 'static + Clone + fmt::Debug,
     {
         let root = self.document.get_element_by_id(root_id).unwrap();
-        self.render_node(&old.as_ref(), &Some(new), &root, 0)?;
+        self.render_node(&old, &Some(new), &root, 0)?;
 
         Ok(())
     }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -97,12 +97,12 @@ where
     }
 
     fn get_child(element: &Element, index: u32) -> Result<Node, JsValue> {
-        Ok(element
+        element
             .dyn_ref::<Node>()
             .unwrap()
             .child_nodes()
             .item(index)
-            .unwrap())
+            .ok_or_else(|| format!("no child at index {}", index).into())
     }
 
     fn remove_child(element: &Element, index: u32) -> Result<(), JsValue> {

--- a/src/virtual_dom.rs
+++ b/src/virtual_dom.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::{fmt, rc::Rc};
 
 pub enum Event<Message> {
     Click(Message),
@@ -38,6 +38,13 @@ pub struct Element<Message> {
     pub children: Vec<Node<Message>>,
 }
 
+impl<Message> fmt::Debug for Element<Message> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.name.fmt(f)
+    }
+}
+
+#[derive(Debug)]
 pub enum Node<Message> {
     Element(Element<Message>),
     Text(String),
@@ -62,6 +69,14 @@ impl<Message> Node<Message> {
     ) -> Node<Message> {
         Node::Element(Element {
             name: "span".into(),
+            attributes,
+            children,
+        })
+    }
+
+    pub fn p(attributes: Vec<Attribute<Message>>, children: Vec<Node<Message>>) -> Node<Message> {
+        Node::Element(Element {
+            name: "p".into(),
             attributes,
             children,
         })


### PR DESCRIPTION
And also networking, to give an example of a type of command. I didn't follow the Elm implementation of this very closely because Elm's commands are provided by the standard library and (I think) users can't write their own.

## Testing

Type different username/repo combinations in the text field and click on "Fetch PRs".